### PR TITLE
Change initial query from GET to HEAD

### DIFF
--- a/main.py
+++ b/main.py
@@ -86,7 +86,7 @@ async def check_url(_):
                 filename = random_string() + ext
                 random_url = URL + filename
                 try:
-                    async with session.get(random_url, timeout=5) as response:
+                    async with session.head(random_url, timeout=5) as response:
                         urls_scanned += 1
 
                         if response.status == 200:


### PR DESCRIPTION
No point in running a full GET query twice (once in the initial query and again in the download).